### PR TITLE
Separate reading list from project catalog

### DIFF
--- a/material/projects.md
+++ b/material/projects.md
@@ -2,8 +2,6 @@
 
 These are example projects of various sorts that might inspire ideas. Not all of them are full stack, or open source.  Some don't even work properly. But they are all interesting. 
 
-- [AI API Walkthroughs](https://www.clarkduvall.com/ai/walkthrough.html#prompt-api) An interactive guide that demonstrates on-device browser AI APIs like the Prompt, Translation, and Summarizer APIs with runnable code snippets | reading <https://www.clarkduvall.com/ai/walkthrough.html#prompt-api>
-
 - [Rubik's Cube 2D](https://claire-bomb.itch.io/rubiks-cube-2d) An itch.io page for a small 2D Rubik's Cube puzzle game playable in the browser | project <https://claire-bomb.itch.io/rubiks-cube-2d>
 
 - [Y Combinator Portfolio Constellation](https://starwatcher.ai/constellations/yc-portfolio) An interactive visualization that maps YC portfolio companies as a navigable “constellation” to explore patterns across industries | project <https://starwatcher.ai/constellations/yc-portfolio>
@@ -14,29 +12,15 @@ These are example projects of various sorts that might inspire ideas. Not all of
 
 - [Mechaverse](https://mechaverse.dev/) A browser-based 3D robot model viewer supporting URDF, MJCF, and OpenUSD with a live demo and open source repo | project <https://mechaverse.dev/>
 
-- [Embit - Signals from Technosphere](https://embit.ca/) A minimalist tech news and link aggregator with a curated “of interest” feed and tag cloud | reading <https://embit.ca/>
-
 - 404 <https://trickle.so/apps/colorfind>
   
-- [Challenge: XR2000](https://clearsky.dev/blog/xr2000/) Blog post announcing a sci‑fi themed programming challenge with a network service to connect to via netcat | reading <https://clearsky.dev/blog/xr2000/>
-- [A gentle introduction to anchor positioning](https://webkit.org/blog/17240/a-gentle-introduction-to-anchor-positioning/) WebKit post that explains CSS anchor positioning for menus and tooltips with practical examples | reading <https://webkit.org/blog/17240/a-gentle-introduction-to-anchor-positioning/>
-- [My AI Code Prep & Cline Workflow for Budget Coding/Debugging (Part 1)](https://wuu73.org/blog/aiguide1.html) Guide to low‑cost AI‑assisted coding, browser setup, and a workflow using AI Code Prep with tools like Cline and Gemini | reading <https://wuu73.org/blog/aiguide1.html>
-- [No, AI is not Making Engineers 10x as Productive](https://colton.dev/blog/curing-your-ai-10x-engineer-imposter-syndrome/) Essay arguing 10x AI productivity claims are overstated, with analysis of bottlenecks and practical limits | reading <https://colton.dev/blog/curing-your-ai-10x-engineer-imposter-syndrome/>
-- [The HTML Hobbyist](https://www.htmlhobbyist.com/) Instructional site that teaches hand‑coded HTML and shows how to publish a simple site, including a one‑page starter | reading <https://www.htmlhobbyist.com/>
-
 - [Timdle: Daily Timeline Game](https://www.timdle.com/) A daily browser timeline game where you place historical events in order, with an option to create custom games | project <https://www.timdle.com/>
-
-- [Two billion people don't have safe drinking water: what does this really mean for them?](https://ourworldindata.org/what-no-safe-water-means) An Our World in Data explainer that defines levels of drinking water access and shows how lack of safe water affects time, health, and daily life | reading <https://ourworldindata.org/what-no-safe-water-means>
-
-- [Git Notes: git's coolest, most unloved feature](https://tylercipriani.com/blog/2022/11/19/git-notes-gits-coolest-most-unloved-feature/) A practical guide to git notes with commands, real use cases like code review metadata, and limitations | reading <https://tylercipriani.com/blog/2022/11/19/git-notes-gits-coolest-most-unloved-feature/>
 
 - [Poline: Esoteric Color Palette Generation Library](https://meodai.github.io/poline/) A TypeScript library and playground for generating color palettes via polar-coordinate interpolation, with npm and CDN usage notes | project <https://meodai.github.io/poline/>
 
 - [Workout.cool](https://github.com/Snouzy/workout-cool) An open source fitness coaching platform that lets you plan workouts, track progress, and import a rich exercise database, with self-hosting guides | project <https://github.com/Snouzy/workout-cool>
 
 - 404 <https://btmc.substack.com/p/implementing-logic-programming>
-
-- [Introducing Copilot Spaces: A new way to work with code and context](https://github.blog/changelog/2025-05-29-introducing-copilot-spaces-a-new-way-to-work-with-code-and-context/) GitHub changelog post announcing Copilot Spaces to centralize code, docs, and custom instructions so Copilot is grounded in project context; shareable across orgs | reading <https://github.blog/changelog/2025-05-29-introducing-copilot-spaces-a-new-way-to-work-with-code-and-context/>
 
 - 404 <https://addyo.substack.com/p/the-prompt-engineering-playbook-for>
 
@@ -45,13 +29,8 @@ These are example projects of various sorts that might inspire ideas. Not all of
 - [Draw a Fish](https://drawafish.com/) A community drawing game where you sketch a fish facing right and watch it swim in a shared global tank, with ranking and personal tanks | project <https://drawafish.com/>
 
 - [Unsure Calculator](https://filiph.github.io/unsure/) An uncertainty-aware calculator that lets you compute with ranges using the ~ notation and see distributions and percentiles | project <https://filiph.github.io/unsure/>
-- [The Fuzzing Book](https://www.fuzzingbook.org/) An online, executable textbook on fuzzing and automated test generation with Python and Jupyter notebooks, covering mutation, grammar, and symbolic techniques | reading <https://www.fuzzingbook.org/>
 
 - [Every HTML Element](https://iamwillwang.com/dollar/every-html-element/) A single web page that uses nearly every HTML element with live examples for forms, media, tables, and a native dialog | project <https://iamwillwang.com/dollar/every-html-element/>
-
-- [Beej's Guide to Git](https://beej.us/guide/bggit/) A comprehensive Git guide in HTML and PDF with practical explanations and command examples | reading <https://beej.us/guide/bggit/>
-
-- [Good software development habits](https://zarar.dev/good-software-development-habits/) A post outlining ten habits for faster, higher‑quality work like tiny commits, frequent deploys, continuous refactoring, and testable design | reading <https://zarar.dev/good-software-development-habits/>
 
 - [Horizon](https://github.com/dnlzro/horizon) Renders the current sky at your approximate location as a CSS gradient, server‑rendered with Astro and no client JavaScript | project <https://github.com/dnlzro/horizon>
 
@@ -63,11 +42,7 @@ These are example projects of various sorts that might inspire ideas. Not all of
 
 - 404 <https://drumpatterns.onether.com/>
 
-- [Engineering.fyi](https://engineering.fyi/) Aggregator of software engineering posts from top companies with tag and company filters | reading <https://engineering.fyi/>
-
 - [SQL Noir](https://www.sqlnoir.com/) An interactive browser game where you learn SQL by solving detective cases with real queries; open source and playable online | project <https://www.sqlnoir.com/>
-
-- [Temple 26 and Excavation Tunnels, Copan](https://mused.com/guided/158/temple-26-and-excavation-tunnels-copan-ruinas/) A guided explainer on Copan’s excavation tunnels with a digital 3D model and notes on conservation planning and site conditions | reading <https://mused.com/guided/158/temple-26-and-excavation-tunnels-copan-ruinas/>
 
 - [Libredesk](https://github.com/abhinavxd/libredesk) Modern open source self‑hosted customer support desk in a single binary with shared inboxes, automation, and webhooks | project <https://github.com/abhinavxd/libredesk>
 
@@ -76,3 +51,11 @@ These are example projects of various sorts that might inspire ideas. Not all of
 - [Theretowhere](https://theretowhere.com/) Map‑based search tool to find apartments and hotels close to places you care about | project <https://theretowhere.com/>
 
 - [Lynx.Boo](https://lynx.boo/) A minimal link in bio site to create a fast-loading personal links page under /username, editable anytime via /yourusername/edit | project <https://lynx.boo/>
+
+- [Challenge: XR2000](https://clearsky.dev/blog/xr2000/) Blog post announcing a sci‑fi themed programming challenge with a network service to connect to via netcat | project <https://clearsky.dev/blog/xr2000/>
+
+- [Embit - Signals from Technosphere](https://embit.ca/) A minimalist tech news and link aggregator with a curated “of interest” feed and tag cloud | project <https://embit.ca/>
+
+- [Engineering.fyi](https://engineering.fyi/) Aggregator of software engineering posts from top companies with tag and company filters | project <https://engineering.fyi/>
+
+- [Temple 26 and Excavation Tunnels, Copan](https://mused.com/guided/158/temple-26-and-excavation-tunnels-copan-ruinas/) A guided explainer on Copan’s excavation tunnels with a digital 3D model and notes on conservation planning and site conditions | project <https://mused.com/guided/158/temple-26-and-excavation-tunnels-copan-ruinas/>

--- a/material/reading.md
+++ b/material/reading.md
@@ -1,0 +1,23 @@
+# Reading material
+
+- [AI API Walkthroughs](https://www.clarkduvall.com/ai/walkthrough.html#prompt-api) An interactive guide that demonstrates on-device browser AI APIs like the Prompt, Translation, and Summarizer APIs with runnable code snippets | reading <https://www.clarkduvall.com/ai/walkthrough.html#prompt-api>
+
+- [A gentle introduction to anchor positioning](https://webkit.org/blog/17240/a-gentle-introduction-to-anchor-positioning/) WebKit post that explains CSS anchor positioning for menus and tooltips with practical examples | reading <https://webkit.org/blog/17240/a-gentle-introduction-to-anchor-positioning/>
+
+- [My AI Code Prep & Cline Workflow for Budget Coding/Debugging (Part 1)](https://wuu73.org/blog/aiguide1.html) Guide to low‑cost AI‑assisted coding, browser setup, and a workflow using AI Code Prep with tools like Cline and Gemini | reading <https://wuu73.org/blog/aiguide1.html>
+
+- [No, AI is not Making Engineers 10x as Productive](https://colton.dev/blog/curing-your-ai-10x-engineer-imposter-syndrome/) Essay arguing 10x AI productivity claims are overstated, with analysis of bottlenecks and practical limits | reading <https://colton.dev/blog/curing-your-ai-10x-engineer-imposter-syndrome/>
+
+- [The HTML Hobbyist](https://www.htmlhobbyist.com/) Instructional site that teaches hand‑coded HTML and shows how to publish a simple site, including a one‑page starter | reading <https://www.htmlhobbyist.com/>
+
+- [Two billion people don't have safe drinking water: what does this really mean for them?](https://ourworldindata.org/what-no-safe-water-means) An Our World in Data explainer that defines levels of drinking water access and shows how lack of safe water affects time, health, and daily life | reading <https://ourworldindata.org/what-no-safe-water-means>
+
+- [Git Notes: git's coolest, most unloved feature](https://tylercipriani.com/blog/2022/11/19/git-notes-gits-coolest-most-unloved-feature/) A practical guide to git notes with commands, real use cases like code review metadata, and limitations | reading <https://tylercipriani.com/blog/2022/11/19/git-notes-gits-coolest-most-unloved-feature/>
+
+- [Introducing Copilot Spaces: A new way to work with code and context](https://github.blog/changelog/2025-05-29-introducing-copilot-spaces-a-new-way-to-work-with-code-and-context/) GitHub changelog post announcing Copilot Spaces to centralize code, docs, and custom instructions so Copilot is grounded in project context; shareable across orgs | reading <https://github.blog/changelog/2025-05-29-introducing-copilot-spaces-a-new-way-to-work-with-code-and-context/>
+
+- [The Fuzzing Book](https://www.fuzzingbook.org/) An online, executable textbook on fuzzing and automated test generation with Python and Jupyter notebooks, covering mutation, grammar, and symbolic techniques | reading <https://www.fuzzingbook.org/>
+
+- [Beej's Guide to Git](https://beej.us/guide/bggit/) A comprehensive Git guide in HTML and PDF with practical explanations and command examples | reading <https://beej.us/guide/bggit/>
+
+- [Good software development habits](https://zarar.dev/good-software-development-habits/) A post outlining ten habits for faster, higher‑quality work like tiny commits, frequent deploys, continuous refactoring, and testable design | reading <https://zarar.dev/good-software-development-habits/>


### PR DESCRIPTION
## Summary
- remove reading entries from `material/projects.md`
- create `material/reading.md` to host reading resources
- move `Engineering.fyi`, `Temple 26 and Excavation Tunnels, Copan`, `Embit`, and `Challenge: XR2000` back into the projects catalog

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6314762148326b5179b9ec1ac4d79