### PR TITLE
Add course README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Full Stack Course
+
+Welcome to the Full Stack Development course. This repository contains lectures, assignments, and reference material for students who want to learn how to build, deploy, and maintain full stack applications.
+
+## Repository Structure
+
+- `lectures/` – weekly lecture notes
+- `assignments/` – exercises and projects that accompany the lectures
+- `material/` – supplemental readings and resources
+
+## First Lecture
+
+Start with [Week 36 – Full Stack Development](lectures/36.md), which introduces the course and its philosophy.
+
+## Contributing
+
+Please open an issue or submit a pull request if you find a problem or have suggestions.
+


### PR DESCRIPTION
## Summary
- add overview README introducing full stack development course
- include repository layout and link to the first lecture

## Testing
- `npx markdownlint README.md` *(fails: 403 Forbidden when fetching markdownlint package)*

------
https://chatgpt.com/codex/tasks/task_e_68ad78ac89508326bef29a1ae2a3a070